### PR TITLE
explorer sort and search fixes

### DIFF
--- a/neotoma/app/neotoma.js
+++ b/neotoma/app/neotoma.js
@@ -70,7 +70,7 @@
                                 if (response.success) {
                                     // make sure data was returned
                                     if (response.data.length === 0) {
-                                        alert("No dataset with id = " + ddatasetId + " was found.");
+                                        alert("No dataset with id = " + datasetId + " was found.");
                                         return;
                                     }
 
@@ -102,17 +102,20 @@
                                         databasename: obj.databasename
                                     }];
 
+                                    // convert response to Explorer Search response
+                                    var searchResponse = this.datasetsToExplorerSearchResponse([response.data[0]]);
+
                                     // publish topic with new response
                                     topic.publish("neotoma/search/NewResult", {
-                                        data: [standardResponse],
-                                        searchName: "datasetid: " + datasetid,
-                                        request: { datasetId: datasetId },
+                                        data: searchResponse,
+                                        searchName: "datasetid: " + datasetId,
+                                        request: { datasetid: datasetId },
                                         symbol: { "color": "ff0000", "shape": "Square", "size": "Large" }
                                     }
                                     );
 
                                     // load dataset explorer
-                                    mainToolbar.showDatasetExplorer(datasetid, obj.datasettype, obj.databasename, standardResponse);
+                                    // mainToolbar.showDatasetExplorer(datasetId, obj.datasettype, obj.databasename, standardResponse);
                                     //showDatasetExplorer(datasetid, obj.datasettype);
                                 } else {
                                     alert(response.message);
@@ -139,16 +142,24 @@
                                         alert("No datasets found with ids in " + datasetIds + ".");
                                         return;
                                     }
+                                    
+                                    // remove duplicate dataset entries from the response 
+                                    var result = response.data.reduce((unique, o) => {
+                                        if(!unique.some(obj => obj.datasetid === o.datasetid)) {
+                                          unique.push(o);
+                                        }
+                                        return unique;
+                                    },[]);
 
                                     // convert response to Explorer Search response
-                                    var searchResponse = this.datasetsToExplorerSearchResponse(response.data);
+                                    var searchResponse = this.datasetsToExplorerSearchResponse(result);
 
                                     // publish topic with new response
                                     topic.publish("neotoma/search/NewResult", {
                                         //data: reformattedSites,
                                         data: searchResponse,
                                         searchName: "DatasetIDs: " + datasetIds,
-                                        request: { datasetIds: datasetIds },
+                                        request: { datasetids: datasetIds },
                                         symbol: { "color": "ff0000", "shape": "Square", "size": "Large" }
                                     }
                                     );
@@ -178,11 +189,14 @@
                                         return;
                                     }
 
+                                    // convert response to Explorer Search response
+                                    var searchResponse = this.datasetsToExplorerSearchResponse(response.data);
+
                                     // publish topic with new response
                                     topic.publish("neotoma/search/NewResult", {
-                                        data: this.datasetsToExplorerSearchResponse(response.data),
+                                        data: searchResponse,
                                         searchName: "SiteIds: " + siteIds,
-                                        request: { siteIds: siteIds },
+                                        request: { siteids: siteIds },
                                         symbol: { "color": "ff0000", "shape": "Square", "size": "Large" }
                                     }
                                     );

--- a/neotoma/search/Metadata.js
+++ b/neotoma/search/Metadata.js
@@ -254,10 +254,6 @@
                             if (response.success) {
                                 // populate store
                                 this._set("store", new Memory({ idProperty: "databaseid", data: response.data }));
-                                // sort store
-                                var sort = { sort: [{ attribute: "DatabaseName", descending: false }] }
-                                //this.set("query", sort);
-                                //var data = grid.get("store").query({}, sort);
                             } else {
                                 alert("response error setting constituent databases: " + response.message);
                             }

--- a/neotoma/search/template/metadata.html
+++ b/neotoma/search/template/metadata.html
@@ -13,7 +13,7 @@
         </tr>
         <tr class="fixht">
             <td class="colSF1">Database</td>
-            <td class="colSF2"><select data-dojo-type="neotoma/widget/FilteringSelect" data-dojo-props="required:false, placeholder:'', searchAttr:'databasename', invalidMessage:'Database not found'" data-dojo-attach-point="database" data-dojo-attach-event="onKeyPress:handleEnter"></select></td>
+            <td class="colSF2"><select data-dojo-type="neotoma/widget/FilteringSelect" data-dojo-props="required:false, placeholder:'', searchAttr:'databasename', fetchProperties:{sort:[{attribute:'databasename',descending:false}]}, invalidMessage:'Database not found'" data-dojo-attach-point="database" data-dojo-attach-event="onKeyPress:handleEnter"></select></td>
         </tr>
         <tr class="fixht">
             <td class="colSF1">Sample keyword</td>
@@ -25,7 +25,7 @@
         </tr>
         <tr class="fixht">
             <td class="colSF1">Person name</td>
-            <td class="colSF2"><select data-dojo-type="neotoma/widget/FilteringSelect" data-dojo-props="required:false, placeholder:'', searchAttr:'contactname', invalidMessage:'Person not found'" data-dojo-attach-point="personName" data-dojo-attach-event="onKeyPress:handleEnter"></select></td>
+            <td class="colSF2"><select data-dojo-type="neotoma/widget/FilteringSelect" data-dojo-props="required:false, placeholder:'', searchAttr:'contactname', fetchProperties:{sort:[{attribute:'contactname',descending:false}]}, invalidMessage:'Person not found'" data-dojo-attach-point="personName" data-dojo-attach-event="onKeyPress:handleEnter"></select></td>
         </tr>
         <tr class="fixht">
             <td class="col1">Date submitted</td>


### PR DESCRIPTION
This PR addresses the following explorer issues:

- Applies alphabetical sort for databases and person names in the metadata pane (resolves [issue 40](https://github.com/NeotomaDB/Explorer/issues/40))
- Allows users to load a single datasetid in URL (e.g., https://apps.neotomadb.org/explorer/?datasetid=1223)
- Allows users to load multiple datasetids in URL (e.g., https://apps.neotomadb.org/explorer/?datasetids=1223,345,232)

This PR does not address issue preventing users to load sites in URL. Based on preliminary investigation, this fix may also require revising the related api endpoints. Further exploration is needed.

cc @SimonGoring @IceAgeEcologist 