### PR TITLE
enable multiple ds and site searches

### DIFF
--- a/neotoma/app/app.js
+++ b/neotoma/app/app.js
@@ -254,11 +254,6 @@
                                 }
                             }));
 
-                            // see if a dataset id was passed
-                            var datasetId = urlUtil.getParameterByName("datasetid") || urlUtil.getParameterByName("datasetId") || urlUtil.getParameterByName("datasetID");
-                            if (datasetId) {
-                                neotoma.loadDataset(datasetId);
-                            }
 
                             // see if datasetids were passed
                             var idsPassed = false;

--- a/neotoma/app/neotoma.js
+++ b/neotoma/app/neotoma.js
@@ -189,8 +189,16 @@
                                         return;
                                     }
 
+                                    // remove duplicate dataset entries from the response 
+                                    var result = response.data.reduce((unique, o) => {
+                                      if(!unique.some(obj => obj.datasetid === o.datasetid)) {
+                                        unique.push(o);
+                                      }
+                                      return unique;
+                                    },[]);
+
                                     // convert response to Explorer Search response
-                                    var searchResponse = this.datasetsToExplorerSearchResponse(response.data);
+                                    var searchResponse = this.datasetsToExplorerSearchResponse(result);
 
                                     // publish topic with new response
                                     topic.publish("neotoma/search/NewResult", {

--- a/neotoma/dialog/SitePopup.js
+++ b/neotoma/dialog/SitePopup.js
@@ -302,7 +302,7 @@
                 var atts = this.sites[this.siteIndex].attributes;
                 // load all datasets if site doesn't have them
                 if (!atts.alldatasets) { // need to get all datasets and then display
-                    script.get(config.dataServicesLocation + "/Datasets", { jsonp: "callback", query: { siteid: atts.siteid } }).then(
+                    script.get(config.dataServicesLocation + "/Datasets", { jsonp: "callback", query: { siteids: atts.siteid } }).then(
                         lang.hitch({ atts: atts, dialog: this }, function (response) {
                             if (response.success) {
                                 var datasets = response.data;

--- a/neotoma/search/All.js
+++ b/neotoma/search/All.js
@@ -147,6 +147,7 @@
                 // make sure there is a search name
                 var searchName = this.searchName.get("value");
                 if (searchName === "") {
+                    searchName = "Search 1";
                     this.searchName.set("value", "Search 1");
                 }
 


### PR DESCRIPTION
This PR enables users to query one or multiple datasets or sites by inputting comma separated ids in the url string. Note that changes to the API will also be pushed to realize this functionality.

Datasets ex.:
https://apps.neotomadb.org/explorer/?datasetids=1234
or
https://apps.neotomadb.org/explorer/?datasetids=1234,3456,234

Sites ex.:
https://apps.neotomadb.org/explorer/?siteids=12
or
https://apps.neotomadb.org/explorer/?siteids=12,123,45

This PR also resolves a minor issue that was preventing a search name designation for the initial search.
