### PR TITLE
enable symbology edits

### DIFF
--- a/neotoma/form/SearchProperties.js
+++ b/neotoma/form/SearchProperties.js
@@ -91,7 +91,7 @@
                             alert("Please select a color.");
                             return null;
                         }
-                        color = color.toLowerCase().replace("#", "");
+                        color = color.toLowerCase();
 
                         // get current properties from form
                         var props = {
@@ -136,3 +136,4 @@
             }
         );
     });
+    


### PR DESCRIPTION
This PR addresses an issue flagged by Thomas Giesecke in slack, in which users were unable to modify the symbology of sites on the map. This bug likely resulted from the September 2021 OpenLayers update. 