### PR TITLE
render depths of 0 in samples tab

### DIFF
--- a/neotoma/form/DatasetExplorer.js
+++ b/neotoma/form/DatasetExplorer.js
@@ -491,7 +491,7 @@
                         outSample["sampleId"] = inSample.sampleid;
                         outSample["sampleName"] = inSample.samplename || "";
                         outSample["unitName"] = inSample.analysisunitname || "";
-                        outSample["depth"] = inSample.depth || "";
+                        inSample.depth == null ? outSample["depth"] = "" : outSample["depth"] = inSample.depth;
                         outSample["thickness"] = inSample.thickness || "";
 
                         // add to outSamples


### PR DESCRIPTION
This commit addresses an issue that was preventing depths of "0" from rendering in the samples tab of the dataset explorer window. 