### PR TITLE
repointing faun map ranges to Neotoma API endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             dbServicesLocation: apiRoot + "v1.5/dbtables",
             dataServicesLocation: apiRoot + "v1.5/data",
             dataServicesLocationV2: apiRoot + "v2.0/data",
-            wfsEndPoint: "https://geo-ub.cei.psu.edu/geoserver/neotoma/ows?",
+            wfsEndPoint: apiRoot + "v2.0/data/spatial/faunal?",
             map: null,
             localDbConfig: {
                 version: 3,


### PR DESCRIPTION
This PR replaces the legacy faunmap ranges endpoint with the current Neotoma API endpoint.

cc @SimonGoring @jessicablois 