### PR TITLE
person search, map disclaimer, and Os icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,11 @@
     view the <a href="./help/Neotoma%20Explorer.html" target="new" style="color: #3366cc;text-decoration: none">documentation</a>.
 </p>
 
+<p style="margin: 5px 10px 0px 10px;">The boundaries, place names, and designations shown on the Neotoma Explorer basemaps are sourced from Open Street Map (OSM) and ESRI, 
+    and do not imply any judgement, official endorsement, or acceptance by the Neotoma Community as to the legal status 
+    and/or boundary delimitation of any country, territory, city, or area.
+</p>
+
 <p style="margin: 10px 10px 0px 10px;">If you use this software, please provide the following citation:</p>
 <p style="margin: 10px 10px 0px 10px;">
     Nelson, J. K., Anderson, M., Bills, B., Stryker, M., Crawford, S., Blois, J., Goring, S. J., & Williams, J. W. (2023). NeotomaDB/Explorer: Neotoma Explorer Version 1.2.0. https://apps.neotomadb.org/explorer. <a href="https://doi.org/10.5281/zenodo.7921067" target="new" style="color: #3366cc;text-decoration: none">DOI: 10.5281/zenodo.7921067</a>.    

--- a/neotoma/app/app.js
+++ b/neotoma/app/app.js
@@ -81,7 +81,7 @@
                                     { datasettype: "ostracode", image: "O.png" },
                                     { datasettype: "water chemistry", image: "W.png" },
                                     { datasettype: "diatom", image: "D.png" },
-                                    { datasettype: "ostracode surface sample", image: "OS.png" },
+                                    { datasettype: "ostracode surface sample", image: "Os.png" },
                                     { datasettype: "diatom surface sample", image: "Ds.png" },
                                     { datasettype: "geochemistry", image: "GC.png" },
                                     { datasettype: "physical sedimentology", image: "S.png" },
@@ -260,15 +260,23 @@
                             }
 
                             var searchParams = urlUtil.getParameterByName("search");
-                            if (searchParams.includes("databaseId")) {
-                              searchParams = JSON.parse(searchParams);
-                              var databaseId = searchParams.metadata.databaseId;
+                            if (searchParams.includes("databaseId") || searchParams.includes("personId")) {
+                                searchParams = JSON.parse(searchParams);
+
+                                var databaseId = searchParams.metadata.databaseId;
+                                var personId = searchParams.metadata.personId;
                             
-                              if (databaseId) {
-                                idsPassed = true;
-                                neotoma.loadDataByDBId(databaseId);
-                              }
-                              
+                                if (typeof databaseId !== 'undefined' && typeof personId !== 'undefined') {
+                                    idsPassed = true;
+                                    neotoma.loadDataByDatabaseIdAndPersonID(databaseId, personId);
+                                } else if (typeof databaseId !== 'undefined' && typeof personId === 'undefined') {
+                                    idsPassed = true;
+                                    neotoma.loadDataByDatabaseId(databaseId);
+                                } else if (typeof databaseId === 'undefined' && typeof personId !== 'undefined') {
+                                    idsPassed = true;
+                                    neotoma.loadDataByPersonId(personId);
+                                }
+
                             }
                             
 

--- a/neotoma/app/neotoma.js
+++ b/neotoma/app/neotoma.js
@@ -177,7 +177,83 @@
                     alert("error in app/neotoma.loadDatasets: " + e.message);
                 }
             },
-            loadDataByDBId: function (databaseId) {
+            loadDataByDatabaseIdAndPersonID: function (databaseId, personId) {
+                try {
+                    // make request to data/datasets
+                    script.get(config.appServicesLocation + '/Search?search={"metadata":{"databaseId":"' + databaseId + '", "personId":"' + personId + '"}}',
+                            { jsonp: "callback" }
+                        ).then(lang.hitch(this, function (response) {
+                            try {
+                                if (response.success) {
+                                    // make sure data was returned
+                                    if (response.data.length === 0) {
+                                        alert("No datasets found with database ID: " + databaseId + " and person ID: " + personId + ".");
+                                        return;
+                                    }
+  
+                                    // convert response to Explorer Search response
+                                    var searchResponse = this.databasesToExplorerSearchResponse(response.data);
+  
+                                    // publish topic with new response
+                                    topic.publish("neotoma/search/NewResult", {
+                                        //data: reformattedSites,
+                                        data: searchResponse,
+                                        searchName: "databaseId: " + databaseId + "personID:" + personId,
+                                        request: { databaseid: databaseId, personid: personId },
+                                        symbol: { "shape": "Circle", "size": "medium", "color": "#238b45" }
+                                    }
+                                    );
+                                } else {
+                                    alert(response.message);
+                                }
+                            } catch (e) {
+                                alert("Error in app/neotoma.loadDatasets:" + e.message);
+                            }
+                        }
+                    ));
+                } catch (e) {
+                    alert("error in app/neotoma.loadDatasets: " + e.message);
+                }
+            },
+            loadDataByPersonId: function (personId) {
+                try {
+                    // make request to data/datasets
+                    script.get(config.appServicesLocation + '/Search?search={"metadata":{"personId":"' + personId + '"}}',
+                            { jsonp: "callback" }
+                        ).then(lang.hitch(this, function (response) {
+                            try {
+                                if (response.success) {
+                                    // make sure data was returned
+                                    if (response.data.length === 0) {
+                                        alert("No datasets found with Person ID: " + personId + ".");
+                                        return;
+                                    }
+  
+                                    // convert response to Explorer Search response
+                                    var searchResponse = this.databasesToExplorerSearchResponse(response.data);
+  
+                                    // publish topic with new response
+                                    topic.publish("neotoma/search/NewResult", {
+                                        //data: reformattedSites,
+                                        data: searchResponse,
+                                        searchName: "personId: " + personId,
+                                        request: { personid: personId },
+                                        symbol: { "shape": "Circle", "size": "medium", "color": "#238b45" }
+                                    }
+                                    );
+                                } else {
+                                    alert(response.message);
+                                }
+                            } catch (e) {
+                                alert("Error in app/neotoma.loadDatasets:" + e.message);
+                            }
+                        }
+                    ));
+                } catch (e) {
+                    alert("error in app/neotoma.loadDatasets: " + e.message);
+                }
+            },
+            loadDataByDatabaseId: function (databaseId) {
               try {
                   // make request to data/datasets
                   script.get(config.appServicesLocation + '/Search?search={"metadata":{"databaseId":"' + databaseId + '"}}',


### PR DESCRIPTION
This PR addresses the following Explorer requests/fixes:

- enables custom URL search by constituent DB Id _and_ person Id (e.g., https://apps.neotomadb.org/explorer/?search={"metadata"{"databaseID:"10,"personId":6527}}) and search by person Id only (e.g., https://apps.neotomadb.org/explorer/?search={"metadata"{"personId":6527}})
- adds basemap disclaimer to About me popup
![Screenshot 2025-06-09 at 1 20 19 PM](https://github.com/user-attachments/assets/e507c1e7-e4d2-43e5-93a3-c853fef7fc92)
- resolves case issue that was preventing Ostracode surface sample icon to render

cc @SimonGoring @IceAgeEcologist 