### PR TITLE
reinstate taxon search with v2 endpoint

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
         <strong>National Science Foundation</strong><br>
         Directorate for Geosciences<br>
         Division of Earth Sciences<br>
-        EAR-1948229, 1948926
+        EAR-1948229, 1948926, 2410961
     </div>
 </p>
 

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 { name: 'amagimap', location: appFolder + 'amagimap' }
             ],
             appServicesLocation: apiRoot + "v1.5/apps",
+            appServicesLocationV2: apiRoot + "v2.0/apps",
             dbServicesLocation: apiRoot + "v1.5/dbtables",
             dataServicesLocation: apiRoot + "v1.5/data",
             dataServicesLocationV2: apiRoot + "v2.0/data",

--- a/neotoma/search/DepEnvt.js
+++ b/neotoma/search/DepEnvt.js
@@ -33,7 +33,7 @@
 
                 // create store with model for tree
                 this.store = new JsonRest({
-                    target: config.appServicesLocation + "/DepositionalEnvironments/",
+                    target: config.appServicesLocationV2 + "/depositionalenvironments/root/",
                     idProperty: "depenvtid",
                     mayHaveChildren: function (object) {
                         // see if it has a children property

--- a/neotoma/search/Taxa.js
+++ b/neotoma/search/Taxa.js
@@ -415,7 +415,7 @@
                 // set message in filtering select
                 if (this.taxonIds.length > 0) {
                     this.taxonName.set({
-                        placeHolder: "Multiple taxa selected",
+                        placeHolder: "One or more taxon selected",
                         value: "",
                         displayedValue: ""
                     });


### PR DESCRIPTION
This PR  reinstates dynamic taxon search functionality with the V2 endpoint and adds the current NSF award number to the about page.