### PR TITLE
add dataset notes, fix csv parsing on export

### DIFF
--- a/neotoma/form/DatasetExplorer.js
+++ b/neotoma/form/DatasetExplorer.js
@@ -1600,6 +1600,12 @@
                       domConstruct.place(domConstruct.create("td", {innerHTML: "PIs", class:"col1"}), row);
                       domConstruct.place(domConstruct.create("td", {innerHTML: pis.join("; "), class:"col2"}), row);
                     }
+                    // dataset notes
+                    if (dataset.collectionunit.dataset.datasetnotes) {
+                        var row = domConstruct.create("tr", { class: "fixht" }, datasetMetadataTable);
+                        domConstruct.place(domConstruct.create("td", { innerHTML: "Notes", class: "col1" }), row);
+                        domConstruct.place(domConstruct.create("td", { innerHTML: dataset.collectionunit.dataset.datasetnotes, class: "col2" }), row);
+                    }
 
                     // place table
                     domConstruct.place(datasetMetadataTable, this.datasetMetadataTableDiv.domNode);

--- a/neotoma/util/export.js
+++ b/neotoma/util/export.js
@@ -12,6 +12,17 @@
                     return;
                 }
 
+                // Helper to escape inner quotes and wrap the value in double quotes
+                function formatCell(val) {
+                    if (val === null || val === undefined) {
+                        return '""';
+                    }
+                    // Convert to string and double up any existing double quotes
+                    var str = String(val).replace(/"/g, '""');
+                    // Wrap the whole cell in double quotes
+                    return '"' + str + '"';
+                }
+
                 // add csv header row
                 var rec1 = data[0];
                 var fields = [];
@@ -20,14 +31,17 @@
                         fields.push(prop);
                     }
                 }
-                csv.push('"' + fields.join('","') + '"');
+                
+                // Process headers safely
+                var quotedHeaders = fields.map(formatCell);
+                csv.push(quotedHeaders.join(","));
 
                 // add data rows
                 var values = null;
                 array.forEach(data, function (jsonRec) {
                     values = [];
                     array.forEach(fields, function (fieldName) {
-                        values.push(jsonRec[fieldName]);
+                        values.push(formatCell(jsonRec[fieldName]));
                     }
                     );
                     csv.push(values.join(","));


### PR DESCRIPTION
@sedv8808 and @jessicablois - this PR exposes dataset notes (when available) in the metadata tab and addresses the following csv download issue:

[NeotomaDB/Explorer] Saving to CSV does not quote text fields leading to data corruption (Issue #85)